### PR TITLE
Update prepend-file to v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "minimist": "^1.2.0",
-    "prepend-file": "^1.3.0"
+    "prepend-file": "1.3.1"
   },
   "xo": {
     "envs": [


### PR DESCRIPTION
This version contains full support for Windows. See https://github.com/hemanth/node-prepend-file/pull/8
I suggest creating a new release (v1.0.5) after this change, so people can start using it. 